### PR TITLE
Update AC, Resource Tap, Aura

### DIFF
--- a/core/SpellData.cs
+++ b/core/SpellData.cs
@@ -205,7 +205,7 @@ namespace EQSpellParser
                         return Spell.FormatCount("Current HP", value) + repeating + range + " (If " + Spell.FormatEnum((SpellTargetRestrict)base2) + ")";
                     return Spell.FormatCount("Current HP", value) + repeating + range;
                 case 1:
-                    return Spell.FormatCount("AC", (int)(value / (10f / 3f)));
+                    return Spell.FormatCountRange("AC", value, (int)Math.Abs(Math.Round((value / 4) * 0.265)), (int)Math.Abs(Math.Round((value / 4) * 0.35))) + ", Based on Class";
                 case 2:
                     return Spell.FormatCount("ATK", value) + range;
                 case 3:
@@ -616,9 +616,8 @@ namespace EQSpellParser
                     if (Version != 0 && Version < 20160816)
                         return String.Format("Lifetap from Weapon Damage: {0}%", base1);
 
-                    return String.Format("Lifetap from Weapon Damage: {0}%", base1 / 10f);
-                // this has been renamed to resource tap. how does it differ from 457?
-                //return string.Format("Return {0}% of Damage as {1}", base1 / 10f, new[] { "HP", "Mana", "Endurance" }[base2 % 3]);
+                    return string.Format("Return {0}% of Melee Damage as {1}", base1 / 10f, new[] { "HP", "Mana", "Endurance" }[base2 % 3]) + (max > 0 ? String.Format(", Max Per Hit: {0}", max) : "");
+                // this has been renamed to resource tap. This is to Melee + Skill Attacks (kick/bash/etc) that 457 is to Spells
                 case 179:
                     return String.Format("Instrument Modifier: {0} {1}", Skill, value);
                 case 180:
@@ -1081,13 +1080,13 @@ namespace EQSpellParser
                         aura = base2;
                     // hardcoded fixes for failed guesses
                     if (ID == 8629) aura = 8628;
+                    if (ID == 8654) aura = 8649;
                     if (ID == 8921) aura = 8935;
                     if (ID == 8922) aura = 8936;
                     if (ID == 8923) aura = 8937;
                     if (ID == 8924) aura = 8959;
                     if (ID == 8925) aura = 8938;
                     if (ID == 8926) aura = 8939;
-                    if (ID == 8654) aura = 8649;
                     if (ID == 8928) aura = 8940;
                     if (ID == 8929) aura = 8943;
                     if (ID == 8930) aura = 8945;
@@ -1108,21 +1107,13 @@ namespace EQSpellParser
                     if (ID == 11521) aura = 11551;
                     if (ID == 11523) aura = 11540;
                     if (ID == 21827) aura = 21848;
-                    if (ID == 32007) aura = 31993;
-                    if (ID == 32271) aura = 32257;
                     if (ID == 22510) aura = 22574;
                     if (ID == 22511) aura = 22575;
+                    if (ID == 32007) aura = 31993;
+                    if (ID == 32271) aura = 32257;
 
-                    // these 3 auras have different effects on normal and swarm pets
-                    if (ID == 49678) aura = 49700;
-                    if (ID == 49679) aura = 49701;
-                    if (ID == 49680) aura = 49702;
-                    //if (ID == 49678) aura = 49736;
-                    //if (ID == 49679) aura = 49737;
-                    //if (ID == 49680) aura = 49738;
-
-                    if (Extra.StartsWith("PCIObMagS17L085TrapPetAug")) aura = 22655;
                     if (Extra.StartsWith("PCIObBrdS17L082AuraRegenRk")) aura = 19713 + Rank;
+                    if (Extra.StartsWith("PCIObMagS17L085TrapPetAug")) aura = 22655;
                     if (Extra.StartsWith("PCIObRogS19L092TrapAggroRk")) aura = 26111 + Rank;
                     if (Extra.StartsWith("PCIObEncS19L095EchoCastProcRk")) aura = 30179 + Rank;
                     if (Extra.StartsWith("PCIObEncS20L100EchoCastProcRk")) aura = 36227 + Rank;
@@ -1130,14 +1121,32 @@ namespace EQSpellParser
                     if (Extra.StartsWith("PCIObEncS22L110EchoCastProcRk")) aura = 57276 + Rank;
 
                     // old aura names (2017-4-19 patch renamed auras)
-                    if (Extra.StartsWith("IOQuicksandTrap85")) aura = 22655;
                     if (Extra.StartsWith("IOAuraCantataRk")) aura = 19713 + Rank;
+                    if (Extra.StartsWith("IOQuicksandTrap85")) aura = 22655;
                     if (Extra.StartsWith("IORogTrapAggro92Rk")) aura = 26111 + Rank;
                     if (Extra.StartsWith("IOEncEchoProc95Rk")) aura = 30179 + Rank;
                     if (Extra.StartsWith("IOEncEchoProc100Rk")) aura = 36227 + Rank;
                     if (Extra.StartsWith("IOEncEchoProc105Rk")) aura = 45018 + Rank;
 
-                    return String.Format("Aura Effect: [Spell {0}] ({1})", aura, Extra);
+                    //if (base2 != 0 && max != 0 && max != 60)
+                    //{
+                        //if (Target == SpellTarget.Pet)
+                        //{
+                            //return String.Format("Aura Effect: [Spell {0}] (Pet) - [Spell {1}] (Swarm Pet) ({2})", max, base2, Extra);
+                        //}
+                        //else if (Target == SpellTarget.Self)
+                        //{
+                            //return String.Format("Aura Effect: [Spell {0}] (Self) - [Spell {1}] (Group) ({2})", max, base2, Extra);
+                        //}
+                        //else
+                        //{
+                            //return String.Format("Aura Effect: [Spell {0}] (UNKNOWN) - [Spell {1}] (UNKNOWN) ({2})", max, base2, Extra);
+                        //}
+                    //}
+                    //else
+                    //{
+                        return String.Format("Aura Effect: [Spell {0}] ({1})", aura, Extra);
+                    //}
                 case 353:
                     return Spell.FormatCount("Aura Slots", base1);
                 case 357:
@@ -1306,7 +1315,7 @@ namespace EQSpellParser
                     return String.Format("Limit Casting Skill: {0}", Spell.FormatEnum((SpellSkill)base1));
                 case 416:
                     // SPA 416 functions exactly like SPA 1, it was added so that we could avoid stacking conflicts with only 12 spell slots. - Dzarn
-                    return Spell.FormatCount("AC", (int)(value / (10f / 3f))) + " (v416)";
+                    return Spell.FormatCountRange("AC", value, (int)Math.Abs(Math.Round((value / 4) * 0.265)), (int)Math.Abs(Math.Round((value / 4) * 0.35))) + ", Based on Class (v416)";
                 case 417:
                     // same as 15 and used for stacking
                     return Spell.FormatCount("Current Mana", value) + repeating + range + " (v417)";
@@ -1412,7 +1421,7 @@ namespace EQSpellParser
                     return Spell.FormatPercent("Current Hate", base1) + " per tick";
                 case 457:
                     // offical name is "Resource Tap"
-                    return string.Format("Return {0}% of Damage as {1}", base1 / 10f, new[] { "HP", "Mana", "Endurance" }[base2 % 3]) + (max > 0 ? String.Format(", Max Per Hit: {0}", max) : "");
+                    return string.Format("Return {0}% of Spell Damage as {1}", base1 / 10f, new[] { "HP", "Mana", "Endurance" }[base2 % 3]) + (max > 0 ? String.Format(", Max Per Hit: {0}", max) : "");
                 case 458:
                     // -100 = no faction hit, 100 = double faction
                     return Spell.FormatPercent("Faction Hit", base1);
@@ -2306,6 +2315,11 @@ namespace EQSpellParser
         private static string FormatCount(string name, int value)
         {
             return String.Format("{0} {1} by {2}", value < 0 ? "Decrease" : "Increase", name, Math.Abs(value));
+        }
+
+        private static string FormatCountRange(string name, int value, int startValue, int endValue)
+        {
+            return String.Format("{0} {1} by {2} to {3}", value < 0 ? "Decrease" : "Increase", name, startValue, endValue);
         }
 
         private static string FormatPercent(string name, float value)

--- a/core/SpellData.cs
+++ b/core/SpellData.cs
@@ -1229,8 +1229,8 @@ namespace EQSpellParser
                     // Cast Time < 2.5 then multiplier = 0.25
                     // Cast Time > 2.5 and < 7 then multiplier = 0.167 * (Cast Time - 1)
                     // Cast Time > 7 then multiplier = 1 * Cast Time / 7
-                    string sample383 = String.Format(" e.g. Cast Time 2s={0}% 3s={1:F1}% 4s={2:F1}% 5s={3:F1}%", 0.25 * (base1 / 10), 0.334 * (base1 / 10), 0.5 * (base1 / 10), 0.668 * (base1 / 10));
-                    return String.Format("Cast: [Spell {0}] on Spell Use (Base1={1})", base2, base1 / 10) + sample383;
+                    string sample383 = String.Format(" e.g. Cast Time 2s={0}% 3s={1}% 4s={2}% 5s={3}%", Math.Min(0.25 * base1, 100), Math.Min(0.334 * base1, 100), Math.Min(0.5 * base1, 100), Math.Min(0.668 * base1, 100));
+                    return String.Format("Cast: [Spell {0}] on Spell Use (Base1={1})", base2, base1) + sample383;
                 case 384:
                     return "Fling to Target";
                 case 385:


### PR DESCRIPTION
Updates AC, Resource Taps, Early work on Auras, needs the htmlappend side to be changed to make both multiple sets of [Spell #] to actually show both

Resource Taps are separate per Melee + Skills vs Spells, this fixes it to display properly. Lifetap on Weapon, unsure if this was the true previous before the potential revamp on the line, so left the previous one the same, but updated current, see Swift Tail's Chant as it restores Endurance on Melee + Skills (inc abilities that have a Skill Attack for its Skill type)

Aura block is int ordered + commented out pre-work on displaying Special Auras that have 2 effects in 1 (Shaman solo+group, magician pet+swarmpet) + a hacky workaround to not show bad data for Wizards aura (has a value of 60 in max/base2 for all ranks, that throws off otherwise), these are the only 3 Auras to have base2+max data atm, appears they flip what they hit based on Target Type. I am not familiar enough with the HTMLAppend methods that is going on to make it so the 2nd [Spell #] link when exists in 1 line is clickable to show its details below (see searching Theft of Essence XI specifically to see the 2nd link shows a link, but doesn't show data when clicked, when the code isn't commented out)

AC: the value/3 was an old formula that was starting to get up to 20-30 AC off by RoF-ish time, with the changes to the AC display awhile ago this stuff is currently significantly off, the best/most concise way to display it is probably to give a range between Druid (Worst) and Warrior (Best), otherwise it requires about 9 distinct AC points to be displayed

Post Softcap
war: value / 4 * 0.35
wiz-enc-mag-nec: value / 3 * 0.25
pal-shd: value / 4 * 0.33
rng: value / 4 * 0.315
brd-clr-mnk: value / 4 * 0.3
ber-rog-bst-sha: value / 4 * 0.285
dru: value / 4 * 0.25

For Pre-Softcap Values, it should be - Int users Value/3, Rest Value/4
Mercenary NPC's use their respective classes values, unsure if general NPC's work this way as well or this is specific Mercenary NPC code.

As mentioned this is probably excessive to display up to 9 unique values, so the Range probably works best since even Naked (ros/tbl beta-ish was the only time I checked recently) Classes are Post-Softcap, and previous Devs suggest anyone in any relevant gear Velious+ was hitting Soft Caps, which is like 95% of the expansions/game. The AC Displays here are also one of the few things to actually Round instead of Truncate